### PR TITLE
Add net input to telegraf conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Role Variables
 | telegraf_input_processes_enabled              | true                           | Enable processes input                                                                                                                                                                                                                                                                 |
 | telegraf_input_swap_enabled                   | true                           | Enable swap input                                                                                                                                                                                                                                                                      |
 | telegraf_input_system_enabled                 | true                           | Enable system input                                                                                                                                                                                                                                                                    |
+| telegraf_input_net_enabled                    | false                          | Enable network input                                                                                                                                                                                                                                                                    |
+
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,3 +67,5 @@ telegraf_input_processes_enabled: true
 telegraf_input_swap_enabled: true
 
 telegraf_input_system_enabled: true
+
+telegraf_input_net_enabled: false

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -186,3 +186,7 @@
 {% if telegraf_input_system_enabled %}
 [[inputs.system]]
 {% endif %}
+
+{% if telegraf_input_net_enabled %}
+[[inputs.net]]
+{% endif %}


### PR DESCRIPTION
Net Input is part of the system plugin. Can we have this option to enabled/disable this one?

Great role,
Thanks
